### PR TITLE
Avoid creating empty class array every invocation.

### DIFF
--- a/src/java/ognl/OgnlRuntime.java
+++ b/src/java/ognl/OgnlRuntime.java
@@ -169,6 +169,8 @@ public class OgnlRuntime {
         }
     }
 
+    private static final Class[] EMPTY_CLASS_ARRAY = new Class[0];
+
     private static IdentityHashMap PRIMITIVE_WRAPPER_CLASSES = new IdentityHashMap();
 
     /**
@@ -2468,7 +2470,7 @@ public class OgnlRuntime {
             context.setCurrentObject(target);
         } else
         {
-            parms = new Class[0];
+            parms = EMPTY_CLASS_ARRAY;
         }
 
         List methods = OgnlRuntime.getMethods(target, name, includeStatic);


### PR DESCRIPTION
Over 1000000 iterations we drop the time by five percent.

// master

elapsed time = 696967607 ns
elapsed time = 679450768 ns
elapsed time = 682986242 ns
elapsed time = 681336507 ns
elapsed time = 681520024 ns
average = 684452229.6 ns

elapsed time = 705903222 ns
elapsed time = 690722676 ns
elapsed time = 681875563 ns
elapsed time = 688540015 ns
elapsed time = 684017613 ns
average = 690211817.8 ns

// with patch

elapsed time = 667203041 ns
elapsed time = 649488893 ns
elapsed time = 659542082 ns
elapsed time = 651563895 ns
elapsed time = 649782366 ns
average = 655516055.4 ns

elapsed time = 663778290 ns
elapsed time = 667921400 ns
elapsed time = 651847408 ns
elapsed time = 650255142 ns
elapsed time = 643630152 ns
average = 655486478.4 ns
