### PR TITLE
Update ExpressionCompiler to run on JDK17+ without 'add-opens' JVM opt using Javassist ClassPool.toClass overload that takes a neighbour class

### DIFF
--- a/src/main/java/ognl/enhance/ExpressionCompiler.java
+++ b/src/main/java/ognl/enhance/ExpressionCompiler.java
@@ -436,7 +436,7 @@ public class ExpressionCompiler implements OgnlExpressionCompiler {
         try {
             newClass.addConstructor(CtNewConstructor.defaultConstructor(newClass));
 
-            Class<?> clazz = pool.toClass(newClass);
+            Class<?> clazz = instantiateClass(pool, newClass);
             newClass.detach();
 
             expression.setAccessor((ExpressionAccessor) clazz.newInstance());
@@ -453,6 +453,21 @@ public class ExpressionCompiler implements OgnlExpressionCompiler {
         }
 
     }
+
+
+    /**
+     * Called when <code>newClass</code> has been fully populated and is ready to be instantiated.
+     *
+     * @param pool     the javassist ClassPool context
+     * @param newClass the definition of the new class
+     * @return The compiled class
+     * @throws CannotCompileException if thrown by javassist
+     */
+    protected Class<?> instantiateClass(final ClassPool pool, final CtClass newClass) throws CannotCompileException
+    {
+        return pool.toClass(newClass, OgnlContext.class);
+    }
+
 
     protected String generateGetter(OgnlContext context, CtClass newClass, ClassPool pool, CtMethod valueGetter, Node expression, Object root) throws Exception {
         String pre = "";


### PR DESCRIPTION
Addresses #160 by pointing Javassist at a neighbour (a class in the same package) class of the class we're generating, allowing it to avoid using the deprecated `ClassLoader.defineClass` (which now requires 'add-opens' to use because Javassist must use reflection to make the method visible), and instead use `MethodHandles`.

This implementation introduces a protected method `instantiateClass` that can be overridden by `ExpressionCompiler` subclassers who are customising the exact mechanics of the class instantiation process if needed.