### PR TITLE
CONFSRVDEV-29911 update OgnlRuntime & ObjectPropertyAccessor to do access check for set field value

### DIFF
--- a/src/main/java/ognl/ObjectPropertyAccessor.java
+++ b/src/main/java/ognl/ObjectPropertyAccessor.java
@@ -49,7 +49,7 @@ public class ObjectPropertyAccessor implements PropertyAccessor {
 
     /**
      * Returns OgnlRuntime.NotFound if the property does not exist.
-     * 
+     *
      * @param context the current execution context.
      * @param target the object to get the property from.
      * @param name the name of the property to get.
@@ -80,7 +80,7 @@ public class ObjectPropertyAccessor implements PropertyAccessor {
 
     /**
      * Returns OgnlRuntime.NotFound if the property does not exist.
-     * 
+     *
      * @param context the current execution context.
      * @param target the object to set the property in.
      * @param name the name of the property to set.
@@ -97,13 +97,13 @@ public class ObjectPropertyAccessor implements PropertyAccessor {
         try {
             if (!OgnlRuntime.setMethodValue(ognlContext, target, name, value, true))
             {
-                result = OgnlRuntime.setFieldValue(ognlContext, target, name, value) ? null : OgnlRuntime.NotFound;
+                result = OgnlRuntime.setFieldValue(ognlContext, target, name, value, true) ? null : OgnlRuntime.NotFound;
             }
 
             if (result == OgnlRuntime.NotFound)
             {
                 Method m = OgnlRuntime.getWriteMethod(target.getClass(), name);
-                if (m != null)
+                if (m != null && ognlContext.getMemberAccess().isAccessible(context, target, m, name))
                 {
                     result = m.invoke(target, new Object[] { value});
                 }

--- a/src/test/java/ognl/ExcludedObjectMemberAccess.java
+++ b/src/test/java/ognl/ExcludedObjectMemberAccess.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2020 OGNL Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ognl;
+
+import java.lang.reflect.Member;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * This class provides simple functionality for mark / unmark an object as inaccessible
+ */
+public class ExcludedObjectMemberAccess extends DefaultMemberAccess {
+    private final List<Object> excludedObjects = new ArrayList<>(); // Any field or method in this list will be inaccessible
+
+    public ExcludedObjectMemberAccess(boolean allowAllAccess) {
+        super(allowAllAccess);
+    }
+
+    public ExcludedObjectMemberAccess(boolean allowPrivateAccess, boolean allowProtectedAccess, boolean allowPackageProtectedAccess) {
+        super(allowPrivateAccess, allowProtectedAccess, allowPackageProtectedAccess);
+    }
+
+    public boolean isAccessible(Map context, Object target, Member member, String propertyName) {
+        if (excludedObjects.contains(member)) {
+            return false;
+        }
+
+        return super.isAccessible(context, target, member, propertyName);
+    }
+
+    public void exclude(Object obj) {
+        excludedObjects.add(obj);
+    }
+
+    public void removeExclusion(Object obj) {
+        excludedObjects.remove(obj);
+    }
+}

--- a/src/test/java/ognl/TestObjectPropertyAccessor.java
+++ b/src/test/java/ognl/TestObjectPropertyAccessor.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2020 OGNL Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ognl;
+
+import junit.framework.TestCase;
+
+import java.beans.IntrospectionException;
+import java.lang.reflect.Method;
+import java.util.Map;
+
+/**
+ * Tests various methods / functionality of {@link ObjectPropertyAccessor}.
+ */
+public class TestObjectPropertyAccessor extends TestCase {
+    private Map context;
+    private ObjectPropertyAccessor propertyAccessor;
+
+    public void setUp() throws Exception {
+        super.setUp();
+        context = Ognl.createDefaultContext(null, new ExcludedObjectMemberAccess(false));
+        propertyAccessor = new ObjectPropertyAccessor();
+    }
+
+    /**
+     * Public class for "setPossibleProperty" method tests.
+     */
+    public static class SimplePublicClass {
+        private String gender = "male";
+        public String email = "test@test.com";
+        private String name = "name";
+        private String age = "18";
+
+        public void setGender(String gender) {
+            this.gender = gender;
+        }
+
+        private void setEmail(String email) {
+            this.email = email;
+        }
+
+        private void setName(String email) {
+            this.email = email;
+        }
+
+        public void setname(String name) {
+            this.name = name;
+        }
+
+        private void setAge(String age) {
+            this.age = age;
+        }
+
+        public void setage(String age) {
+            this.age = age;
+        }
+    }
+
+    public void testSetPossibleProperty() throws OgnlException, IntrospectionException {
+        OgnlContext context = (OgnlContext) this.context;
+        SimplePublicClass simplePublic = new SimplePublicClass();
+
+        // 1. when set method is accessible and set method
+        assertNotSame(OgnlRuntime.NotFound, propertyAccessor.setPossibleProperty(context, simplePublic, "gender", "female"));
+        assertEquals("female", simplePublic.gender);
+
+        // 2. when set method is NOT accessible and fallback to set field (field is accessible)
+        assertNotSame(OgnlRuntime.NotFound, propertyAccessor.setPossibleProperty(context, simplePublic, "email", "admin@admin.com"));
+        assertEquals("admin@admin.com", simplePublic.email);
+
+        // 3. when set method is NOT accessible, field is NOT accessible, fallback to write method (write method is accessible)
+        assertEquals("setName", OgnlRuntime.getSetMethod(context, SimplePublicClass.class, "name").getName());
+        assertEquals("setname", OgnlRuntime.getWriteMethod(SimplePublicClass.class, "name", null).getName());
+        assertNotSame(OgnlRuntime.NotFound, propertyAccessor.setPossibleProperty(context, simplePublic, "name", "new name"));
+        assertEquals("new name", simplePublic.name);
+
+        // 4. when set method is NOT accessible, field is NOT accessible, fallback to write method (write method is NOT accessible)
+        Method ageWriteMethod = OgnlRuntime.getWriteMethod(SimplePublicClass.class, "age", null);
+        ((ExcludedObjectMemberAccess) context.getMemberAccess()).exclude(ageWriteMethod);
+
+        assertEquals("setage", ageWriteMethod.getName());
+        assertFalse(context.getMemberAccess().isAccessible(context, simplePublic, ageWriteMethod, "age"));
+        assertEquals("setAge", OgnlRuntime.getSetMethod(context, SimplePublicClass.class, "age").getName());
+        assertEquals(OgnlRuntime.NotFound, propertyAccessor.setPossibleProperty(context, simplePublic, "age", "99"));
+        assertEquals("18", simplePublic.age);
+    }
+}

--- a/src/test/java/ognl/TestOgnlRuntime.java
+++ b/src/test/java/ognl/TestOgnlRuntime.java
@@ -9,6 +9,7 @@ import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CountDownLatch;
@@ -139,7 +140,7 @@ public class TestOgnlRuntime extends TestCase {
         OgnlContext context = (OgnlContext) this.context;
 
         Object ret = OgnlRuntime.callMethod(context, list, "addValue", new String[] {null});
-        
+
         assert ret != null;
     }
 
@@ -593,7 +594,7 @@ public class TestOgnlRuntime extends TestCase {
 
         // synthetic method would be "public volatile java.util.List org.ognl.test.objects.SubclassSyntheticObject.getList()",
         // causing method return size to be 3
-        
+
         assertEquals(2, result.size());
     }
 
@@ -718,10 +719,10 @@ public class TestOgnlRuntime extends TestCase {
 
     /**
      * Test that synthetic bridge read methods can be found successfully.
-     * 
+     *
      * Note: Only bridge methods should qualify, non-bridge synthetic methods should not.
-     * 
-     * @throws Exception 
+     *
+     * @throws Exception
      */
     public void testSyntheticBridgeReadMethod() throws Exception {
         assertNotNull(OgnlRuntime.getReadMethod(PublicChild.class, "name"));
@@ -729,10 +730,10 @@ public class TestOgnlRuntime extends TestCase {
 
     /**
      * Test that synthetic bridge write methods can be found successfully.
-     * 
+     *
      * Note: Only bridge methods should qualify, non-bridge synthetic methods should not.
-     * 
-     * @throws Exception 
+     *
+     * @throws Exception
      */
     public void testSyntheticBridgeWriteMethod() throws Exception {
         assertNotNull(OgnlRuntime.getWriteMethod(PublicChild.class, "name"));
@@ -819,5 +820,77 @@ public class TestOgnlRuntime extends TestCase {
         assertFalse("SimpleAbstractClass.getName() is a bridge method ?", method.isBridge());
         assertFalse("SimpleAbstractClass.getName() is considered callable by isMethodCallable() ?", OgnlRuntime.isMethodCallable(method));
         assertFalse("SimpleAbstractClass.getName() is considered callable by isMethodCallable_BridgeOrNonSynthetic() ?", OgnlRuntime.isMethodCallable_BridgeOrNonSynthetic(method));
+    }
+
+    /**
+     * Public class for "setFieldValue" method tests.
+     */
+    public static class SimpleFieldClass {
+        public static String NAME = "name";
+        public final List<String> numbers = Arrays.asList("one", "two", "three");
+        public String gender = "male";
+        public String email = "test@test.com";
+        private String address = "1 Glen st";
+    }
+
+    public void testSetFieldValueWhenCheckAccess() throws OgnlException, NoSuchFieldException {
+        OgnlContext context = (OgnlContext) this.context;
+        SimpleFieldClass simpleField = new SimpleFieldClass();
+
+        // verify that the static & final field is NOT accessible and bypass set field value
+        assertFalse(OgnlRuntime.setFieldValue(context, simpleField, "NAME", "new name", true));
+        assertEquals("name", SimpleFieldClass.NAME);
+
+        assertFalse(OgnlRuntime.setFieldValue(context, simpleField, "numbers", Collections.singletonList("four"), true));
+        assertEquals(3, simpleField.numbers.size());
+
+        // verify that the field is accessible and set field value successfully
+        Field genderField = SimpleFieldClass.class.getDeclaredField("gender");
+        assertTrue(context.getMemberAccess().isAccessible(context, simpleField, genderField, null));
+        assertTrue(OgnlRuntime.setFieldValue(context, simpleField, "gender", "female", true));
+        assertEquals("female", simpleField.gender);
+
+        // verify that the field is NOT accessible, and bypass set field value
+        Field addressField = SimpleFieldClass.class.getDeclaredField("address");
+        assertFalse(context.getMemberAccess().isAccessible(context, simpleField, addressField, null));
+        assertFalse(OgnlRuntime.setFieldValue(context, simpleField, "address", "2 Glen st", true));
+        assertEquals("1 Glen st", simpleField.address);
+    }
+
+    public void testSetFieldValueWhenNotCheckAccess() throws OgnlException, NoSuchFieldException {
+        ExcludedObjectMemberAccess memberAccess = new ExcludedObjectMemberAccess(false);
+        OgnlContext context = (OgnlContext) Ognl.createDefaultContext(null, memberAccess);
+        SimpleFieldClass simpleField = new SimpleFieldClass();
+
+        // verify that the static & final field is NOT accessible and bypass set field value
+        assertFalse(OgnlRuntime.setFieldValue(context, simpleField, "NAME", "new name"));
+        assertEquals("name", SimpleFieldClass.NAME);
+
+        assertFalse(OgnlRuntime.setFieldValue(context, simpleField, "numbers", Collections.singletonList("four")));
+        assertEquals(3, simpleField.numbers.size());
+
+        // verify that the field is accessible and set field value successfully
+        Field genderField = SimpleFieldClass.class.getDeclaredField("gender");
+        assertTrue(context.getMemberAccess().isAccessible(context, simpleField, genderField, null));
+        assertTrue(OgnlRuntime.setFieldValue(context, simpleField, "gender", "female"));
+        assertEquals("female", simpleField.gender);
+
+        // verify that even the field is NOT accessible, and it processes to set field value successfully
+        Field emailField = SimpleFieldClass.class.getDeclaredField("email");
+        memberAccess.exclude(emailField);
+        assertFalse(memberAccess.isAccessible(context, simpleField, emailField, null));
+        OgnlRuntime.setFieldValue(context, simpleField, "email", "admin@admin.com");
+        assertEquals("admin@admin.com", simpleField.email);
+
+        // verify that even the field is NOT accessible, and it processes to set field value but throws NoSuchPropertyException (as for private field)
+        Field addressField = SimpleFieldClass.class.getDeclaredField("address");
+        memberAccess.exclude(addressField);
+        assertFalse(memberAccess.isAccessible(context, simpleField, addressField, null));
+        try {
+            OgnlRuntime.setFieldValue(context, simpleField, "address", "2 Glen st");
+        } catch (NoSuchPropertyException e) {
+            assertEquals("ognl.TestOgnlRuntime$SimpleFieldClass.address", e.getMessage());
+            assertEquals("1 Glen st", simpleField.address);
+        }
     }
 }


### PR DESCRIPTION
WW-5417

`OgnlRuntime.setFieldValue` doesn't check member access rights via `MemberAccess` interface

 &nbsp;

**Reason**

* Investigation shows that `getMethodValue`/ `setMethodValue` / `getFieldValue` are all updated with member access rights check but not `setFieldValue`, which cause `ObjectPropertyAccessor#setPossibleProperty` expose to security vuln.
* `ObjectPropertyAccessor#setPossibleProperty` has a fallback mechanism using `getWriteMethod` which also lack member access rights check
 
 &nbsp;

**Changes/ Solution**

* add field member access check to `OgnlRuntime#setFieldValue` that is controlled by parameter `checkAccessAndExistence`
* add method member access check to `ObjectPropertyAccessor#setPossibleProperty` code block that uses `OgnlRuntime#getWriteMethod`
 
 &nbsp;

**Result & Impact**
now `ObjectPropertyAccessor#setPossibleProperty` will also check member access rights when fallback to use:
* OgnlRuntime.setFieldValue
* method invoke that is from OgnlRuntime.getWriteMethod