### PR TITLE
add parameter ignoreReadMethod in ObjectPropertyAccessor

### DIFF
--- a/src/main/java/ognl/ObjectPropertyAccessor.java
+++ b/src/main/java/ognl/ObjectPropertyAccessor.java
@@ -32,20 +32,6 @@ import java.lang.reflect.Method;
 public class ObjectPropertyAccessor implements PropertyAccessor {
 
     /**
-     * Ignore detecting and invoking read method when get property value.
-     */
-    private final boolean ignoreReadMethod;
-
-
-    public ObjectPropertyAccessor() {
-        this(false);
-    }
-
-    public ObjectPropertyAccessor(boolean ignoreReadMethod) {
-        this.ignoreReadMethod = ignoreReadMethod;
-    }
-
-    /**
      * Returns OgnlRuntime.NotFound if the property does not exist.
      *
      * @param context the current execution context.
@@ -58,7 +44,7 @@ public class ObjectPropertyAccessor implements PropertyAccessor {
         Object result;
 
         try {
-            if ((result = OgnlRuntime.getMethodValue(context, target, name, true, ignoreReadMethod)) == OgnlRuntime.NotFound) {
+            if ((result = OgnlRuntime.getMethodValue(context, target, name, true)) == OgnlRuntime.NotFound) {
                 result = OgnlRuntime.getFieldValue(context, target, name, true);
             }
         } catch (OgnlException ex) {

--- a/src/main/java/ognl/ObjectPropertyAccessor.java
+++ b/src/main/java/ognl/ObjectPropertyAccessor.java
@@ -32,6 +32,20 @@ import java.lang.reflect.Method;
 public class ObjectPropertyAccessor implements PropertyAccessor {
 
     /**
+     * Ignore detecting and invoking read method when get property value.
+     */
+    private final boolean ignoreReadMethod;
+
+
+    public ObjectPropertyAccessor() {
+        this(false);
+    }
+
+    public ObjectPropertyAccessor(boolean ignoreReadMethod) {
+        this.ignoreReadMethod = ignoreReadMethod;
+    }
+
+    /**
      * Returns OgnlRuntime.NotFound if the property does not exist.
      *
      * @param context the current execution context.
@@ -44,7 +58,7 @@ public class ObjectPropertyAccessor implements PropertyAccessor {
         Object result;
 
         try {
-            if ((result = OgnlRuntime.getMethodValue(context, target, name, true)) == OgnlRuntime.NotFound) {
+            if ((result = OgnlRuntime.getMethodValue(context, target, name, true, ignoreReadMethod)) == OgnlRuntime.NotFound) {
                 result = OgnlRuntime.getFieldValue(context, target, name, true);
             }
         } catch (OgnlException ex) {

--- a/src/main/java/ognl/OgnlContext.java
+++ b/src/main/java/ognl/OgnlContext.java
@@ -39,7 +39,9 @@ public class OgnlContext implements Map<String, Object> {
     private static final String TRACE_EVALUATIONS_CONTEXT_KEY = "_traceEvaluations";
     private static final String LAST_EVALUATION_CONTEXT_KEY = "_lastEvaluation";
     private static final String KEEP_LAST_EVALUATION_CONTEXT_KEY = "_keepLastEvaluation";
+    private static final String IGNORE_READ_METHODS_CONTEXT_KEY = "_ignoreReadMethods";
     private static final String PROPERTY_KEY_PREFIX = "ognl";
+    private static final boolean DEFAULT_IGNORE_READ_METHODS = false;
     private static boolean DEFAULT_TRACE_EVALUATIONS = false;
     private static boolean DEFAULT_KEEP_LAST_EVALUATION = false;
 
@@ -53,6 +55,7 @@ public class OgnlContext implements Map<String, Object> {
     private Evaluation currentEvaluation;
     private Evaluation lastEvaluation;
     private boolean keepLastEvaluation = DEFAULT_KEEP_LAST_EVALUATION;
+    private boolean ignoreReadMethods = DEFAULT_IGNORE_READ_METHODS;
 
     private final Map<String, Object> internalContext;
 
@@ -67,6 +70,7 @@ public class OgnlContext implements Map<String, Object> {
         RESERVED_KEYS.put(TRACE_EVALUATIONS_CONTEXT_KEY, null);
         RESERVED_KEYS.put(LAST_EVALUATION_CONTEXT_KEY, null);
         RESERVED_KEYS.put(KEEP_LAST_EVALUATION_CONTEXT_KEY, null);
+        RESERVED_KEYS.put(IGNORE_READ_METHODS_CONTEXT_KEY, null);
 
         try {
             String property;
@@ -240,6 +244,26 @@ public class OgnlContext implements Map<String, Object> {
      */
     public void setKeepLastEvaluation(boolean value) {
         keepLastEvaluation = value;
+    }
+
+
+    /**
+     * Returns true if read methods of properties are ignored when accessing properties. The default is false.
+     *
+     * @return true if read methods of properties are ignored when accessing properties, false otherwise.
+     */
+    public boolean isIgnoreReadMethods() {
+        return ignoreReadMethods;
+    }
+
+
+    /**
+     * Sets read methods of properties are ignored when accessing properties. The default is false.
+     *
+     * @param value true if read methods of properties are ignored when accessing properties, false otherwise.
+     */
+    public void setIgnoreReadMethods(boolean value) {
+        this.ignoreReadMethods = value;
     }
 
     public void setCurrentObject(Object value) {
@@ -476,6 +500,9 @@ public class OgnlContext implements Map<String, Object> {
                 case OgnlContext.KEEP_LAST_EVALUATION_CONTEXT_KEY:
                     result = isKeepLastEvaluation() ? Boolean.TRUE : Boolean.FALSE;
                     break;
+                case OgnlContext.IGNORE_READ_METHODS_CONTEXT_KEY:
+                    result = isIgnoreReadMethods() ? Boolean.TRUE : Boolean.FALSE;
+                    break;
                 default:
                     throw new IllegalArgumentException("unknown reserved key '" + key + "'");
             }
@@ -510,6 +537,10 @@ public class OgnlContext implements Map<String, Object> {
                 case OgnlContext.KEEP_LAST_EVALUATION_CONTEXT_KEY:
                     result = isKeepLastEvaluation() ? Boolean.TRUE : Boolean.FALSE;
                     setKeepLastEvaluation(OgnlOps.booleanValue(value));
+                    break;
+                case OgnlContext.IGNORE_READ_METHODS_CONTEXT_KEY:
+                    result = isIgnoreReadMethods() ? Boolean.TRUE : Boolean.FALSE;
+                    setIgnoreReadMethods(OgnlOps.booleanValue(value));
                     break;
                 default:
                     throw new IllegalArgumentException("unknown reserved key '" + key + "'");
@@ -549,6 +580,9 @@ public class OgnlContext implements Map<String, Object> {
                 case OgnlContext.KEEP_LAST_EVALUATION_CONTEXT_KEY:
                     throw new IllegalArgumentException("Can't remove "
                             + OgnlContext.KEEP_LAST_EVALUATION_CONTEXT_KEY + " from context");
+                case OgnlContext.IGNORE_READ_METHODS_CONTEXT_KEY:
+                    throw new IllegalArgumentException("Can't remove "
+                            + OgnlContext.IGNORE_READ_METHODS_CONTEXT_KEY + " from context");
                 default:
                     throw new IllegalArgumentException("Unknown reserved key '" + key + "'");
             }

--- a/src/main/java/ognl/OgnlRuntime.java
+++ b/src/main/java/ognl/OgnlRuntime.java
@@ -1677,7 +1677,7 @@ public class OgnlRuntime {
     @Deprecated
     public static Object getMethodValue(OgnlContext context, Object target, String propertyName)
             throws OgnlException, IllegalAccessException, NoSuchMethodException, IntrospectionException {
-        return getMethodValue(context, target, propertyName, false, false);
+        return getMethodValue(context, target, propertyName, false);
     }
 
     /**
@@ -1696,29 +1696,9 @@ public class OgnlRuntime {
      */
     public static Object getMethodValue(OgnlContext context, Object target, String propertyName, boolean checkAccessAndExistence)
             throws OgnlException, IllegalAccessException, NoSuchMethodException {
-        return getMethodValue(context, target, propertyName, checkAccessAndExistence, false);
-    }
-
-    /**
-     * If the checkAccessAndExistence flag is true this method will check to see if the method
-     * exists and if it is accessible according to the context's MemberAccess. If neither test
-     * passes this will return NotFound.
-     *
-     * @param context                 the current execution context.
-     * @param target                  the object to invoke the property name get on.
-     * @param propertyName            the name of the property to be retrieved from target.
-     * @param checkAccessAndExistence true if this method should check access levels and existence for propertyName of target, false otherwise.
-     * @param ignoreReadMethod        true if this method should try to detect and invoke read method of the target property, false otherwise.
-     * @return the result invoking property retrieval of propertyName for target.
-     * @throws OgnlException          for lots of different reasons.
-     * @throws IllegalAccessException if access not permitted.
-     * @throws NoSuchMethodException  if no property accessor exists.
-     */
-    public static Object getMethodValue(OgnlContext context, Object target, String propertyName, boolean checkAccessAndExistence, boolean ignoreReadMethod)
-            throws OgnlException, IllegalAccessException, NoSuchMethodException {
         Object result = null;
         Method m = getGetMethod((target == null) ? null : target.getClass(), propertyName);
-        if (m == null && !ignoreReadMethod)
+        if (m == null && !context.isIgnoreReadMethods())
             m = getReadMethod((target == null) ? null : target.getClass(), propertyName, null);
 
         if (checkAccessAndExistence) {

--- a/src/main/java/ognl/OgnlRuntime.java
+++ b/src/main/java/ognl/OgnlRuntime.java
@@ -1677,7 +1677,7 @@ public class OgnlRuntime {
     @Deprecated
     public static Object getMethodValue(OgnlContext context, Object target, String propertyName)
             throws OgnlException, IllegalAccessException, NoSuchMethodException, IntrospectionException {
-        return getMethodValue(context, target, propertyName, false);
+        return getMethodValue(context, target, propertyName, false, false);
     }
 
     /**
@@ -1696,9 +1696,29 @@ public class OgnlRuntime {
      */
     public static Object getMethodValue(OgnlContext context, Object target, String propertyName, boolean checkAccessAndExistence)
             throws OgnlException, IllegalAccessException, NoSuchMethodException {
+        return getMethodValue(context, target, propertyName, checkAccessAndExistence, false);
+    }
+
+    /**
+     * If the checkAccessAndExistence flag is true this method will check to see if the method
+     * exists and if it is accessible according to the context's MemberAccess. If neither test
+     * passes this will return NotFound.
+     *
+     * @param context                 the current execution context.
+     * @param target                  the object to invoke the property name get on.
+     * @param propertyName            the name of the property to be retrieved from target.
+     * @param checkAccessAndExistence true if this method should check access levels and existence for propertyName of target, false otherwise.
+     * @param ignoreReadMethod        true if this method should try to detect and invoke read method of the target property, false otherwise.
+     * @return the result invoking property retrieval of propertyName for target.
+     * @throws OgnlException          for lots of different reasons.
+     * @throws IllegalAccessException if access not permitted.
+     * @throws NoSuchMethodException  if no property accessor exists.
+     */
+    public static Object getMethodValue(OgnlContext context, Object target, String propertyName, boolean checkAccessAndExistence, boolean ignoreReadMethod)
+            throws OgnlException, IllegalAccessException, NoSuchMethodException {
         Object result = null;
         Method m = getGetMethod((target == null) ? null : target.getClass(), propertyName);
-        if (m == null)
+        if (m == null && !ignoreReadMethod)
             m = getReadMethod((target == null) ? null : target.getClass(), propertyName, null);
 
         if (checkAccessAndExistence) {

--- a/src/test/java/ognl/OgnlContextTest.java
+++ b/src/test/java/ognl/OgnlContextTest.java
@@ -24,10 +24,7 @@ import org.junit.jupiter.api.Test;
 import java.util.HashMap;
 import java.util.Map;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 class OgnlContextTest {
 
@@ -124,5 +121,19 @@ class OgnlContextTest {
 
     private static OgnlContext createOgnlContext() {
         return new OgnlContext(null, null, new DefaultMemberAccess(false));
+    }
+
+    @Test
+    void ignoreReadMethod() {
+        OgnlContext context = createOgnlContext();
+        assertFalse(context.isIgnoreReadMethods());
+        assertEquals(Boolean.FALSE, context.get("_ignoreReadMethods"));
+        context.setIgnoreReadMethods(true);
+        assertTrue(context.isIgnoreReadMethods());
+        assertEquals(Boolean.TRUE, context.get("_ignoreReadMethods"));
+        assertEquals(Boolean.TRUE, context.put("_ignoreReadMethods", false));
+        assertFalse(context.isIgnoreReadMethods());
+        assertEquals(Boolean.FALSE, context.get("_ignoreReadMethods"));
+        assertThrows(IllegalArgumentException.class, () -> context.remove("_ignoreReadMethods"));
     }
 }

--- a/src/test/java/ognl/TestObjectPropertyAccessor.java
+++ b/src/test/java/ognl/TestObjectPropertyAccessor.java
@@ -84,7 +84,9 @@ public class TestObjectPropertyAccessor extends TestCase {
         OgnlContext context = (OgnlContext) this.context;
         KafkaFetcher fetcher = new KafkaFetcher();
         assertEquals(Boolean.FALSE, propertyAccessor.getPossibleProperty(context, fetcher, "completedFutures"));
-        assertEquals(Collections.emptyList(), new ObjectPropertyAccessor(true).getPossibleProperty(Ognl.createDefaultContext(null, new ExcludedObjectMemberAccess(true)),
+        OgnlContext defaultContext = Ognl.createDefaultContext(null, new ExcludedObjectMemberAccess(true));
+        defaultContext.setIgnoreReadMethods(true);
+        assertEquals(Collections.emptyList(), new ObjectPropertyAccessor().getPossibleProperty(defaultContext,
                 fetcher, "completedFutures"));
     }
 

--- a/src/test/java/ognl/TestObjectPropertyAccessor.java
+++ b/src/test/java/ognl/TestObjectPropertyAccessor.java
@@ -19,7 +19,11 @@ import junit.framework.TestCase;
 
 import java.beans.IntrospectionException;
 import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 import java.util.Map;
+import java.util.concurrent.Future;
 
 /**
  * Tests various methods / functionality of {@link ObjectPropertyAccessor}.
@@ -66,6 +70,22 @@ public class TestObjectPropertyAccessor extends TestCase {
         public void setage(String age) {
             this.age = age;
         }
+    }
+
+    public static class KafkaFetcher {
+        private final List<Future<?>> completedFutures = new ArrayList<>();
+
+        public boolean hasCompletedFutures() {
+            return !completedFutures.isEmpty();
+        }
+    }
+
+    public void testGetPossibleProperty() throws OgnlException {
+        OgnlContext context = (OgnlContext) this.context;
+        KafkaFetcher fetcher = new KafkaFetcher();
+        assertEquals(Boolean.FALSE, propertyAccessor.getPossibleProperty(context, fetcher, "completedFutures"));
+        assertEquals(Collections.emptyList(), new ObjectPropertyAccessor(true).getPossibleProperty(Ognl.createDefaultContext(null, new ExcludedObjectMemberAccess(true)),
+                fetcher, "completedFutures"));
     }
 
     public void testSetPossibleProperty() throws OgnlException, IntrospectionException {


### PR DESCRIPTION
current implementation of getting property using `ObjectPropertyAccessor` will firstly try to find get method of target property,
if no get method found then try to find read method. If read method exist returns the return value of the read method。Sometimes read method does not directly returns the value of property. For example   the class `org.apache.kafka.clients.consumer.internals.Fetcher` , it has a property `completedFetches`, and a method `hasCompletedFetches` which will be recognized as a read method of the property `completedFetches`,  it returns a boolean value instead of the actural value of `completedFetches`. But what I need is to get the elements of ConcurrentLinkedQueue. So I think we should offer a parameter to ignore detecting read method in this case.
```
public class Fetcher<K, V> implements Closeable {
   
    private final int maxPollRecords;
    private final boolean checkCrcs;
    private final String clientRackId;
    private final ConsumerMetadata metadata;
    private final FetchManagerMetrics sensors;
    private final SubscriptionState subscriptions;
    private final ConcurrentLinkedQueue<CompletedFetch> completedFetches;
   
    private final ApiVersions apiVersions;

    private PartitionRecords nextInLineRecords = null;

  
    public boolean hasCompletedFetches() {
        return !completedFetches.isEmpty();
    }
}
```