### PR TITLE
Fix Claude workflow validation error for bot PRs

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -2,7 +2,7 @@ name: Claude Code Review
 
 on:
   pull_request:
-    types: [opened, synchronize]
+    types: [ opened, synchronize ]
     # Optional: Only run on specific file changes
     # paths:
     #   - "src/**/*.ts"
@@ -12,12 +12,9 @@ on:
 
 jobs:
   claude-review:
-    # Optional: Filter by PR author
-    # if: |
-    #   github.event.pull_request.user.login == 'external-contributor' ||
-    #   github.event.pull_request.user.login == 'new-developer' ||
-    #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
-
+    # Skip bot PRs (especially Renovate) to avoid workflow file modification conflicts
+    if: github.event.pull_request.user.type != 'Bot'
+    
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
## Summary
- Adds a filter to skip bot PRs in the Claude Code Review workflow
- Prevents workflow validation errors when bots (like Renovate) modify workflow files

## Problem
The Claude GitHub App was failing on PR #452 (and similar bot PRs) with:
```
Error: Failed to setup GitHub token: Error: Workflow validation failed. 
The workflow file must exist and have identical content to the version 
on the repository's default branch.
```

This occurs because the Claude App validates that workflow files are identical between the PR and main branch as a security measure. When Renovate or other bots update dependencies in workflow files (e.g., `actions/checkout@v4` → `v5`), this validation fails.

## Solution
Added a conditional filter to skip bot PRs:
```yaml
if: github.event.pull_request.user.type != 'Bot'
```

This ensures:
- ✅ Human-created PRs still get Claude code reviews
- ✅ Bot PRs (Renovate, Dependabot, etc.) are skipped, avoiding validation errors
- ✅ Security is maintained by preventing workflow file modifications through the Claude App

## Test Plan
- [x] Verify workflow file syntax is valid
- [ ] Merge this PR to main
- [ ] Verify PR #452 no longer triggers the Claude workflow
- [ ] Verify human PRs still trigger Claude reviews

🤖 Generated with [Claude Code](https://claude.com/claude-code)