### PR TITLE
Remove SecurityManager support

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,10 +72,6 @@ to ask or report an issue.
             }
         };
      ```
- - How to run OGNL in Google AppEngine?
-   - you need to tell OGNL to not do security manager permission checks, which will fail since GAE has a security manager 
-     and you don't have the ability to add the OGNL-specific permissions. Therefore, somewhere in your initialization code, 
-     add this `OgnlRuntime.setSecurityManager(null);`.
  - How to use the latest SNAPSHOT version?
    - Define OSS Sonatype repository in `~/.m2/settings.xml` as follows:
      ```xml

--- a/ognl/src/main/java/ognl/OgnlRuntime.java
+++ b/ognl/src/main/java/ognl/OgnlRuntime.java
@@ -193,7 +193,7 @@ public class OgnlRuntime {
             // Should not happen.  To debug, uncomment the next line.
             //throw new IllegalStateException("OgnlRuntime initialization missing setAccessible method", nsme);
         } catch (SecurityException se) {
-            // May be blocked by existing SecurityManager.  To debug, uncomment the next line.
+            // To debug, uncomment the next line.
             //throw new SecurityException("OgnlRuntime initialization cannot access setAccessible method", se);
         } finally {
             AO_SETACCESSIBLE_REF = setAccessibleMethod;
@@ -205,7 +205,7 @@ public class OgnlRuntime {
             // Should not happen.  To debug, uncomment the next line.
             //throw new IllegalStateException("OgnlRuntime initialization missing setAccessible method", nsme);
         } catch (SecurityException se) {
-            // May be blocked by existing SecurityManager.  To debug, uncomment the next line.
+            // To debug, uncomment the next line.
             //throw new SecurityException("OgnlRuntime initialization cannot access setAccessible method", se);
         } finally {
             AO_SETACCESSIBLE_ARR_REF = setAccessibleMethodArray;
@@ -217,7 +217,7 @@ public class OgnlRuntime {
             // Should not happen.  To debug, uncomment the next line.
             //throw new IllegalStateException("OgnlRuntime initialization missing exit method", nsme);
         } catch (SecurityException se) {
-            // May be blocked by existing SecurityManager.  To debug, uncomment the next line.
+            // To debug, uncomment the next line.
             //throw new SecurityException("OgnlRuntime initialization cannot access exit method", se);
         } finally {
             SYS_EXIT_REF = systemExitMethod;
@@ -229,7 +229,7 @@ public class OgnlRuntime {
             // May happen for JDK 1.5 and earlier.  To debug, uncomment the next line.
             //throw new IllegalStateException("OgnlRuntime initialization missing console method", nsme);
         } catch (SecurityException se) {
-            // May be blocked by existing SecurityManager.  To debug, uncomment the next line.
+            // To debug, uncomment the next line.
             //throw new SecurityException("OgnlRuntime initialization cannot access console method", se);
         } finally {
             SYS_CONSOLE_REF = systemConsoleMethod;


### PR DESCRIPTION
Removes SecurityManager references from the OGNL codebase.

## Changes
- Remove SecurityManager references from code comments in OgnlRuntime.java
- Remove Google AppEngine SecurityManager documentation from README.md
- Keep historical references in VersionNotes.md as part of release history

SecurityManager was deprecated in Java 17 and removed in Java 21. This change prepares the codebase for future Java versions.

Fixes #355

Generated with [Claude Code](https://claude.ai/code)