### PR TITLE
Refactor coverage profile configuration and update badges

### DIFF
--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -49,12 +49,6 @@ jobs:
           path: ~/.sonar/cache
           key: ${{ runner.os }}-sonar
           restore-keys: ${{ runner.os }}-sonar
-      - name: Cache Maven packages
-        uses: actions/cache@v4
-        with:
-          path: ~/.m2
-          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
-          restore-keys: ${{ runner.os }}-m2
       - name: Build with Maven
         run: ./mvnw -B package -DskipTests=true
       - name: Test with coverage

--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 # Object-Graph Navigation Language - OGNL
 
 [![Java CI](https://github.com/orphan-oss/ognl/actions/workflows/maven.yml/badge.svg)](https://github.com/orphan-oss/ognl/actions/workflows/maven.yml)
+[![Maven Central](https://maven-badges.sml.io/sonatype-central/ognl/ognl/badge.svg)](https://maven-badges.sml.io/sonatype-central/ognl/ognl/)
+[![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=orphan-oss_ognl&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=orphan-oss_ognl)
 [![Coverage](https://sonarcloud.io/api/project_badges/measure?project=orphan-oss_ognl&metric=coverage)](https://sonarcloud.io/summary/new_code?id=orphan-oss_ognl)
-[![Maven Central](https://maven-badges.herokuapp.com/maven-central/ognl/ognl/badge.svg)](https://maven-badges.herokuapp.com/maven-central/ognl/ognl/)
 [![CII Best Practices](https://bestpractices.coreinfrastructure.org/projects/6490/badge)](https://bestpractices.coreinfrastructure.org/projects/6490)
 [![License](http://img.shields.io/:license-apache-blue.svg)](http://www.apache.org/licenses/LICENSE-2.0.html)
 

--- a/ognl/pom.xml
+++ b/ognl/pom.xml
@@ -166,4 +166,51 @@
 
     </build>
 
+    <profiles>
+        <profile>
+            <id>coverage</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.sonarsource.scanner.maven</groupId>
+                        <artifactId>sonar-maven-plugin</artifactId>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.jacoco</groupId>
+                        <artifactId>jacoco-maven-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>prepare-agent</id>
+                                <goals>
+                                    <goal>prepare-agent</goal>
+                                </goals>
+                            </execution>
+                            <execution>
+                                <id>report</id>
+                                <goals>
+                                    <goal>report</goal>
+                                </goals>
+                                <configuration>
+                                    <formats>
+                                        <format>XML</format>
+                                    </formats>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <argLine>
+                                @{argLine}
+                                --add-opens java.base/java.lang=ALL-UNNAMED
+                                --add-opens java.base/java.util=ALL-UNNAMED
+                            </argLine>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -234,51 +234,6 @@
                 </pluginManagement>
             </build>
         </profile>
-        <profile>
-            <id>coverage</id>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.sonarsource.scanner.maven</groupId>
-                        <artifactId>sonar-maven-plugin</artifactId>
-                    </plugin>
-                    <plugin>
-                        <groupId>org.jacoco</groupId>
-                        <artifactId>jacoco-maven-plugin</artifactId>
-                        <executions>
-                            <execution>
-                                <id>prepare-agent</id>
-                                <goals>
-                                    <goal>prepare-agent</goal>
-                                </goals>
-                            </execution>
-                            <execution>
-                                <id>report</id>
-                                <goals>
-                                    <goal>report</goal>
-                                </goals>
-                                <configuration>
-                                    <formats>
-                                        <format>XML</format>
-                                    </formats>
-                                </configuration>
-                            </execution>
-                        </executions>
-                    </plugin>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-surefire-plugin</artifactId>
-                        <configuration>
-                            <argLine>
-                                @{argLine}
-                                --add-opens java.base/java.lang=ALL-UNNAMED
-                                --add-opens java.base/java.util=ALL-UNNAMED
-                            </argLine>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
     </profiles>
 
 </project>


### PR DESCRIPTION
## Summary
- Move coverage profile from parent pom to ognl module for better separation of concerns
- Update Maven Central badge URL to use smli.io (previous herokuapp.com domain is deprecated)
- Add Quality Gate Status badge for better visibility of code quality
- Remove redundant Maven cache configuration from Sonar workflow

## Test plan
- [x] Verify CI builds pass
- [x] Confirm SonarCloud integration still works correctly
- [x] Check that badges display properly in README

🤖 Generated with [Claude Code](https://claude.com/claude-code)