### PR TITLE
fix(ci): add SonarCloud coverage report path configuration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,4 +1,5 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>ognl</groupId>
@@ -16,6 +17,9 @@
         <sonar.host.url>https://sonarcloud.io</sonar.host.url>
         <sonar.organization>orphan-oss</sonar.organization>
         <sonar.projectKey>orphan-oss_ognl</sonar.projectKey>
+        <sonar.coverage.jacoco.xmlReportPaths>
+            ${project.basedir}/ognl/target/site/jacoco/jacoco.xml
+        </sonar.coverage.jacoco.xmlReportPaths>
 
         <javassist.version>3.30.2-GA</javassist.version>
         <junit.version>6.0.1</junit.version>


### PR DESCRIPTION
## Summary

Fixes the issue where SonarCloud was reporting 0% code coverage despite tests running with coverage enabled.

## Changes

- Added `sonar.coverage.jacoco.xmlReportPaths` property to root `pom.xml` pointing to the JaCoCo XML report location in the `ognl` module

## Root Cause

In multi-module Maven projects, SonarCloud needs explicit configuration to locate JaCoCo coverage reports. Without the `sonar.coverage.jacoco.xmlReportPaths` property, SonarCloud cannot find the generated coverage data.

## Impact

- SonarCloud will now correctly import coverage data from the ognl module
- Coverage metrics will appear on the SonarCloud dashboard
- Future PRs will show accurate code coverage percentages

## Test Plan

- [x] Configuration change verified in root pom.xml
- [ ] Wait for CI workflow to complete and verify SonarCloud imports coverage
- [ ] Check SonarCloud dashboard shows non-zero coverage percentage

🤖 Generated with [Claude Code](https://claude.com/claude-code)