### PR TITLE
fix: throw OgnlException for out-of-range integer literals

### DIFF
--- a/ognl/src/main/java/ognl/Ognl.java
+++ b/ognl/src/main/java/ognl/Ognl.java
@@ -115,7 +115,8 @@ public abstract class Ognl {
      *
      * @param expression the OGNL expression to be parsed
      * @return a tree representation of the expression
-     * @throws ExpressionSyntaxException if the expression is malformed
+     * @throws ExpressionSyntaxException if the expression is malformed, including an integer
+     *                                   literal whose value is outside the representable range
      * @throws OgnlException             if there is a pathological environmental problem
      */
     public static Object parseExpression(String expression) throws OgnlException {

--- a/ognl/src/main/javacc/ognl.jj
+++ b/ognl/src/main/javacc/ognl.jj
@@ -1916,7 +1916,10 @@ TOKEN_MGR_DECLS:
         } catch ( NumberFormatException e ) {
             // Surface as a lexical error so callers see the documented OgnlException
             // instead of a raw NumberFormatException (e.g. literals out of range).
-            throw new TokenMgrError( "Integer literal out of range: " + image, TokenMgrError.LEXICAL_ERROR );
+            // TokenMgrError has no cause-accepting constructor, so fold the original
+            // detail into the message to keep diagnostics and use the caught exception.
+            throw new TokenMgrError( "Integer literal out of range: " + image
+                    + " (" + e.getMessage() + ")", TokenMgrError.LEXICAL_ERROR );
         }
         return result;
     }

--- a/ognl/src/main/javacc/ognl.jj
+++ b/ognl/src/main/javacc/ognl.jj
@@ -1899,18 +1899,24 @@ TOKEN_MGR_DECLS:
             base = (s.length() > 1 && (s.charAt(1) == 'x' || s.charAt(1) == 'X'))? 16 : 8;
         if ( base == 16 )
             s = s.substring(2); // Trim the 0x off the front
-        switch ( s.charAt(s.length()-1) ) {
-            case 'l': case 'L':
-                result = Long.valueOf( s.substring(0,s.length()-1), base );
-                break;
+        try {
+            switch ( s.charAt(s.length()-1) ) {
+                case 'l': case 'L':
+                    result = Long.valueOf( s.substring(0,s.length()-1), base );
+                    break;
 
-            case 'h': case 'H':
-                result = new BigInteger( s.substring(0,s.length()-1), base );
-                break;
+                case 'h': case 'H':
+                    result = new BigInteger( s.substring(0,s.length()-1), base );
+                    break;
 
-            default:
-                result = Integer.valueOf( s, base );
-                break;
+                default:
+                    result = Integer.valueOf( s, base );
+                    break;
+            }
+        } catch ( NumberFormatException e ) {
+            // Surface as a lexical error so callers see the documented OgnlException
+            // instead of a raw NumberFormatException (e.g. literals out of range).
+            throw new TokenMgrError( "Integer literal out of range: " + image, TokenMgrError.LEXICAL_ERROR );
         }
         return result;
     }

--- a/ognl/src/test/java/ognl/test/IntegerLiteralOverflowTest.java
+++ b/ognl/src/test/java/ognl/test/IntegerLiteralOverflowTest.java
@@ -20,10 +20,10 @@ package ognl.test;
 
 import ognl.Ognl;
 import ognl.OgnlException;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class IntegerLiteralOverflowTest {
@@ -31,6 +31,8 @@ class IntegerLiteralOverflowTest {
     @ParameterizedTest
     @ValueSource(strings = {
             "2147483648",            // decimal above Integer.MAX_VALUE
+            "-2147483648",           // lexer tokenises the leading '-' separately,
+                                     // so makeInt() sees the bare 2147483648
             "9999999999",            // larger decimal
             "9223372036854775808L",  // long above Long.MAX_VALUE
             "0xFFFFFFFF",            // hex above signed 32-bit range
@@ -39,5 +41,16 @@ class IntegerLiteralOverflowTest {
     })
     void shouldThrowOgnlExceptionForOutOfRangeIntegerLiteral(String expression) {
         assertThrows(OgnlException.class, () -> Ognl.parseExpression(expression));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "2147483647",            // Integer.MAX_VALUE
+            "9223372036854775807L",  // Long.MAX_VALUE
+            "0x7FFFFFFF",            // largest in-range hex int
+            "1e100"                  // float path is unaffected by makeInt()
+    })
+    void shouldParseInRangeNumericLiteral(String expression) {
+        assertDoesNotThrow(() -> Ognl.parseExpression(expression));
     }
 }

--- a/ognl/src/test/java/ognl/test/IntegerLiteralOverflowTest.java
+++ b/ognl/src/test/java/ognl/test/IntegerLiteralOverflowTest.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package ognl.test;
+
+import ognl.Ognl;
+import ognl.OgnlException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class IntegerLiteralOverflowTest {
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "2147483648",            // decimal above Integer.MAX_VALUE
+            "9999999999",            // larger decimal
+            "9223372036854775808L",  // long above Long.MAX_VALUE
+            "0xFFFFFFFF",            // hex above signed 32-bit range
+            "0x100000000",
+            "0xFFFFFFFFFFFFFFFFL"
+    })
+    void shouldThrowOgnlExceptionForOutOfRangeIntegerLiteral(String expression) {
+        assertThrows(OgnlException.class, () -> Ognl.parseExpression(expression));
+    }
+}


### PR DESCRIPTION
Fixes #583. Integer literals that overflow their target type (decimal above Integer.MAX_VALUE, long above Long.MAX_VALUE, and all hex literals in the upper half of the unsigned range) currently let a raw NumberFormatException escape parseExpression, which breaks the documented OgnlException contract that callers like Struts rely on. This wraps the failure in makeInt() as a TokenMgrError so it surfaces through the existing parseExpression handler as an OgnlException. Added a parameterized test covering the decimal, long, and hex overflow cases.