### PR TITLE
fix: throw OgnlException for out-of-range integer literals (backport #590 to ognl-3-4-x)

### DIFF
--- a/src/main/java/ognl/Ognl.java
+++ b/src/main/java/ognl/Ognl.java
@@ -123,7 +123,8 @@ public abstract class Ognl {
      *
      * @param expression the OGNL expression to be parsed
      * @return a tree representation of the expression
-     * @throws ExpressionSyntaxException if the expression is malformed
+     * @throws ExpressionSyntaxException if the expression is malformed, including an integer
+     *                                   literal whose value is outside the representable range
      * @throws OgnlException             if there is a pathological environmental problem
      */
     public static Object parseExpression(String expression) throws OgnlException {

--- a/src/main/javacc/ognl.jj
+++ b/src/main/javacc/ognl.jj
@@ -1898,18 +1898,27 @@ TOKEN_MGR_DECLS:
             base = (s.length() > 1 && (s.charAt(1) == 'x' || s.charAt(1) == 'X'))? 16 : 8;
         if ( base == 16 )
             s = s.substring(2); // Trim the 0x off the front
-        switch ( s.charAt(s.length()-1) ) {
-            case 'l': case 'L':
-                result = Long.valueOf( s.substring(0,s.length()-1), base );
-                break;
+        try {
+            switch ( s.charAt(s.length()-1) ) {
+                case 'l': case 'L':
+                    result = Long.valueOf( s.substring(0,s.length()-1), base );
+                    break;
 
-            case 'h': case 'H':
-                result = new BigInteger( s.substring(0,s.length()-1), base );
-                break;
+                case 'h': case 'H':
+                    result = new BigInteger( s.substring(0,s.length()-1), base );
+                    break;
 
-            default:
-                result = Integer.valueOf( s, base );
-                break;
+                default:
+                    result = Integer.valueOf( s, base );
+                    break;
+            }
+        } catch ( NumberFormatException e ) {
+            // Surface as a lexical error so callers see the documented OgnlException
+            // instead of a raw NumberFormatException (e.g. literals out of range).
+            // TokenMgrError has no cause-accepting constructor, so fold the original
+            // detail into the message to keep diagnostics and use the caught exception.
+            throw new TokenMgrError( "Integer literal out of range: " + image
+                    + " (" + e.getMessage() + ")", TokenMgrError.LEXICAL_ERROR );
         }
         return result;
     }

--- a/src/test/java/ognl/test/IntegerLiteralOverflowTest.java
+++ b/src/test/java/ognl/test/IntegerLiteralOverflowTest.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package ognl.test;
+
+import ognl.Ognl;
+import ognl.OgnlException;
+import org.junit.Test;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThrows;
+
+/**
+ * Tests that integer literals outside the representable range surface as an {@link OgnlException}
+ * rather than a raw {@link NumberFormatException}, as documented by {@link Ognl#parseExpression(String)}.
+ * <p>
+ * Backport of #590 (issue #583).
+ */
+public class IntegerLiteralOverflowTest {
+
+    private static final String[] OUT_OF_RANGE = {
+            "2147483648",            // decimal above Integer.MAX_VALUE
+            "-2147483648",           // lexer tokenises the leading '-' separately,
+                                     // so makeInt() sees the bare 2147483648
+            "9999999999",            // larger decimal
+            "9223372036854775808L",  // long above Long.MAX_VALUE
+            "0xFFFFFFFF",            // hex above signed 32-bit range
+            "0x100000000",
+            "0xFFFFFFFFFFFFFFFFL"
+    };
+
+    private static final String[] IN_RANGE = {
+            "2147483647",            // Integer.MAX_VALUE
+            "9223372036854775807L",  // Long.MAX_VALUE
+            "0x7FFFFFFF",            // largest in-range hex int
+            "1e100"                  // float path is unaffected by makeInt()
+    };
+
+    @Test
+    public void shouldThrowOgnlExceptionForOutOfRangeIntegerLiteral() {
+        for (final String expression : OUT_OF_RANGE) {
+            assertThrows("Expected an OgnlException for out-of-range literal: " + expression,
+                    OgnlException.class, () -> Ognl.parseExpression(expression));
+        }
+    }
+
+    @Test
+    public void shouldParseInRangeNumericLiteral() throws OgnlException {
+        for (String expression : IN_RANGE) {
+            assertNotNull("Expected " + expression + " to parse", Ognl.parseExpression(expression));
+        }
+    }
+}


### PR DESCRIPTION
Backports #590 (issue #583) to `ognl-3-4-x`.

## Problem

`makeInt()` in the lexer let `NumberFormatException` escape for integer literals outside the representable range, so `Ognl.parseExpression()` broke its documented contract of throwing `OgnlException`.

## Fix

Same change as #590: the out-of-range literal is reported as a lexical error (`TokenMgrError`), which `parseExpression()` already wraps in `ExpressionSyntaxException`. `TokenMgrError` has no cause-accepting constructor, so the original detail is folded into the message to keep diagnostics.

Covers decimal above `Integer.MAX_VALUE`, the `-2147483648` case (the lexer tokenises the leading `-` separately, so `makeInt()` sees the bare `2147483648`), `L`-suffixed values above `Long.MAX_VALUE`, and hex above the signed 32-bit range. In-range boundaries and the float path are asserted to still parse.

## Differences from #590

- **Paths**: 3.4.x is single-module, so `ognl/src/…` → `src/…`.
- **Test framework**: the test is written against **JUnit 4** rather than the JUnit 5 original. This branch pins surefire to the `surefire-junit47` provider (`pom.xml`), so Jupiter tests are not discovered here — ported verbatim, the test reported `Tests run: 0` and `BUILD SUCCESS` while the bug was still present. Filed separately.
- `src/main/jjtree/ognl.jjt` is deliberately left untouched; it has drifted from `ognl.jj` on both branches. Filed separately.

## Verification

`./mvnw clean verify` — **995 tests, 0 failures, 0 errors** on both **JDK 8** (this branch's target) and JDK 17.

Confirmed failing before the fix and passing after:
```
expected:<ognl.OgnlException> but was:<java.lang.NumberFormatException>
```

Co-authored-by: Sai Asish Y <say.apm35@gmail.com>