### PR TITLE
fix: run JUnit 5 tests again and repair the two bugs they expose

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -126,13 +126,6 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
                     <version>${maven-surefire-plugin.version}</version>
-                    <dependencies>
-                        <dependency>
-                            <groupId>org.apache.maven.surefire</groupId>
-                            <artifactId>surefire-junit47</artifactId>
-                            <version>${maven-surefire-plugin.version}</version>
-                        </dependency>
-                    </dependencies>
                     <configuration>
                         <includes>
                             <include>**/*Test.java</include>

--- a/src/main/java/ognl/ASTMethod.java
+++ b/src/main/java/ognl/ASTMethod.java
@@ -69,6 +69,12 @@ public class ASTMethod extends SimpleNode implements OrderedReturn, NodeType {
             args[i] = children[i].getValue(context, root);
         }
 
+        if (source == null) {
+            // mirrors OgnlRuntime.getProperty() for a null source: callers are documented to
+            // see an OgnlException, not a raw NullPointerException from OgnlRuntime.callMethod()
+            throw new OgnlException("source is null for callMethod(null, \"" + methodName + "\")");
+        }
+
         result = OgnlRuntime.callMethod(context, source, methodName, args);
 
         if (result == null) {

--- a/src/main/java/ognl/Ognl.java
+++ b/src/main/java/ognl/Ognl.java
@@ -399,6 +399,12 @@ public abstract class Ognl {
      * @throws OgnlException                    if there is a pathological environmental problem
      */
     public static Object getValue(Object tree, OgnlContext context, Object root, Class<?> resultType) throws OgnlException {
+        // an explicitly passed root wins when the context does not define one, see #309;
+        // a non-null context root is left alone so nested evaluations keep the original root
+        if (context.getRoot() == null) {
+            context.setRoot(root);
+        }
+
         Object result;
 
         Node node = (Node) tree;

--- a/src/test/java/ognl/test/ShortCircuitingExpressionTest.java
+++ b/src/test/java/ognl/test/ShortCircuitingExpressionTest.java
@@ -28,11 +28,13 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.fail;
 
 class ShortCircuitingExpressionTest {
@@ -129,11 +131,24 @@ class ShortCircuitingExpressionTest {
         assertEquals("name", val2);
     }
 
+    /**
+     * Accessing a property or calling a method on a null target throws instead of returning null.
+     * The chain short-circuit that used to return null here was removed in #476 (issue #472);
+     * ChainTest and NullRootTest were updated at the time, this test was not, because the
+     * surefire junit47 provider pin stopped it from running (#614).
+     */
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "(#x=99)? #x.someProperty : #x",  // property access on a non-null target that lacks it
+            "#xyzzy.doubleValue()"            // method call on a null target
+    })
+    void shouldThrowOgnlExceptionForNullTargetAccess(String expression) {
+        assertThrows(OgnlException.class, () -> Ognl.getValue(expression, null));
+    }
+
     private static Stream<Arguments> testValues() {
         return Stream.of(
                 Arguments.of("#root ? someProperty : 99", 99),
-                Arguments.of("(#x=99)? #x.someProperty : #x", null),
-                Arguments.of("#xyzzy.doubleValue()", null),
                 Arguments.of("#xyzzy && #xyzzy.doubleValue()", null),
                 Arguments.of("#xyzzy || 101", 101),
                 Arguments.of("99 || 101", 99)


### PR DESCRIPTION
Closes #614
Closes #615

## The pin

`maven-surefire-plugin` pinned the `surefire-junit47` provider, which does not discover JUnit 5 tests:

```
[INFO] Using configured provider org.apache.maven.surefire.junitcore.JUnitCoreProvider
[INFO] Tests run: 0
[INFO] BUILD SUCCESS
```

Nine Jupiter test files have not run since that pin landed in `735d3fcf` (2024-12-30). Removing it lets the auto-detected `JUnitPlatformProvider` run both frameworks — the JUnit 3/4 tests via `junit-vintage-engine`, which is already a declared dependency.

**995 → 1106 tests.** All nine previously dormant files now execute:

| Test class | Tests |
|---|---|
| `ognl.OgnlContextTest` | 12 |
| `ognl.test.ShortCircuitingExpressionTest` | 11 |
| `ognl.test.ContextRootPreservationTest` | 8 |
| `ognl.test.NullHandlerTest` | 4 |
| `ognl.test.NullSafeIntegrationTest` | 17 |
| `ognl.test.NullSafeCompilationTest` | 6 |
| `ognl.test.NullSafeOperatorTest` | 35 |
| `ognl.test.MemberAccessTest` | 5 |
| `ognl.test.NullSafeCollectionTest` | 13 |

## Bug 1 — #309 regressed (`Ognl.java`)

`Ognl.getValue(tree, context, root, resultType)` stopped honouring an explicitly passed `root` when the context's root was null:

```java
OgnlContext ctx = Ognl.createDefaultContext(null);
Ognl.getValue("\"a\".equals(params[0].b)", ctx, root);
// ognl.OgnlException: source is null for getProperty(null, "params")
```

`6fd535da` added that guard for #309 on 2024-12-29 together with the `shouldCompare` test; the pin landed **the next day**, and `043a716c` (#476) removed the guard 10 months later with nothing to catch it. It has shipped in 3.4.8–3.4.12.

Restoring the guard keeps #472 fixed — `Issue472CustomMethodAccessorTest` and `ContextRootPreservationTest` both pass.

## Bug 2 — raw NPE escaping (`ASTMethod.java`)

A method call on a null target let `java.lang.NullPointerException` escape `Ognl.getValue`, breaking the documented `OgnlException` contract — the same class of violation as #583.

`ASTMethod` now reports it the way `OgnlRuntime.getProperty()` already reports a null source. Two deliberate choices:

- the check sits **after** argument evaluation, so argument side effects keep their previous ordering;
- public `OgnlRuntime.callMethod()` is left untouched and stays identical to `main`.

## Test expectations

`ShortCircuitingExpressionTest` still carried two expectations from the chain short-circuit that #476 deliberately removed ("null property access now throws OgnlException"). `ChainTest` and `NullRootTest` were updated at the time; this file was missed because it was invisible. Those two cases now assert the `OgnlException` that #476 introduced.

Note this is a real behavioural divergence from `main`, which never took #476 and still short-circuits in `ASTChain.getValueBody`. This PR encodes 3.4.x's shipped behaviour rather than changing it.

## Verification

`./mvnw clean verify` — **1106 tests, 0 failures, 0 errors** on **JDK 8** and **JDK 17**.
`./mvnw clean verify -Pcoverage` still produces `jacoco.xml`; instruction coverage **72.2% → 73.1%**.

The first bad commit for all three failures was found with `git bisect run`: `043a716c`.