### PR TITLE
docs: replace the PR #TBD placeholder with #558

### DIFF
--- a/docs/plans/ISSUE_18_COMPILED_MODE_PARITY.md
+++ b/docs/plans/ISSUE_18_COMPILED_MODE_PARITY.md
@@ -56,7 +56,7 @@ The original issue #18 reported 85 failures. Investigation shows:
 ## Remaining Work
 
 ### ~~PR: String Escaping Fix (category 5)~~ — DONE
-**Fixed in PR #TBD.** Root cause: `ASTAdd.toGetSourceString()` lines 208-214 replaced `"` with `'` in string constants during compiled concatenation. Fix: use proper Java string escaping (`\"`) instead of single-quote substitution, and preserve `&quot;` as literal text.
+**Fixed in PR #558.** Root cause: `ASTAdd.toGetSourceString()` lines 208-214 replaced `"` with `'` in string constants during compiled concatenation. Fix: use proper Java string escaping (`\"`) instead of single-quote substitution, and preserve `&quot;` as literal text.
 
 ### ~~PR: instanceof Support (category 3)~~ — DONE
 **Fixed in PR #559.** Root cause: `ASTInstanceof.toGetSourceString()` didn't set `_noRoot` flag, causing `ExpressionCompiler.generateGetter()` to prepend root expression (`$2.`) to the generated source (`true`), producing invalid Java source `$2.true`.


### PR DESCRIPTION
One-word documentation fix.

`docs/plans/ISSUE_18_COMPILED_MODE_PARITY.md` credited the string-escaping fix to "PR #TBD". That entry was written by the very PR that implemented the fix, so its number did not exist yet at authoring time.

It was **[PR #558](https://github.com/orphan-oss/ognl/pull/558)** — `fix(compiler): proper string escaping in ASTAdd concatenation`, merged 2026-04-01 as `e8fb900f`, touching `ognl/src/main/java/ognl/ASTAdd.java`, `DualModeEvaluationTest.java` and this plan file.

Phrasing matches the adjacent instanceof entry, which reads "Fixed in PR #559."

Spotted while reviewing project notes against the repo; it was the only `TBD` left in the file.